### PR TITLE
Add support for movie appends_to_response query parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ phpunit.xml
 composer.lock
 vendor/
 .coverage/
+.idea/
 .env

--- a/src/Collections/VideoCollection.php
+++ b/src/Collections/VideoCollection.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Astrotomic\Tmdb\Collections;
+
+use Astrotomic\Tmdb\Data\Video;
+use Illuminate\Support\Collection as IlluminateCollection;
+
+/**
+ * @template TKey of int
+ * @template TValue of Video
+ *
+ * @extends IlluminateCollection<TKey, TValue>
+ */
+class VideoCollection extends IlluminateCollection
+{
+    /**
+     * @param  array<TKey, array> $data
+     * @return self<TKey, TValue>
+     */
+    public static function fromArray(?array $data): self
+    {
+        return new static(array_map(
+            fn (array $item): Video => Video::fromArray($item),
+            $data ?? []
+        ));
+    }
+
+    /**
+     * @param  iterable<TKey, TValue>|null  $items
+     */
+    final public function __construct($items = [])
+    {
+        parent::__construct($items);
+
+        $this->ensure(Video::class);
+    }
+}

--- a/src/Data/AlternativeTitle.php
+++ b/src/Data/AlternativeTitle.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Astrotomic\Tmdb\Data;
+
+readonly class AlternativeTitle
+{
+    final public function __construct(
+        public int   $id,
+        public array $titles,
+    ){}
+
+    public static function fromArray(array $data): self
+    {
+        return new static(
+            id: $data['id'] ?? 0,
+            titles: array_map(
+                fn(array $title): Title => Title::fromArray($title),
+                $data['titles'] ?? []
+            ),
+        );
+    }
+}

--- a/src/Data/ExternalIds.php
+++ b/src/Data/ExternalIds.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Astrotomic\Tmdb\Data;
+
+readonly class ExternalIds
+{
+    final public function __construct(
+        public int $id,
+        public ?string $imdbId,
+        public ?string $wikidataId,
+        public ?string $facebookId,
+        public ?string $instagramId,
+        public ?string $twitterId,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new static(
+            id: $data['id'] ?? 0,
+            imdbId: $data['imdb_id'] ?? null,
+            wikidataId: $data['wikidata_id'] ?? null,
+            facebookId: $data['facebook_id'] ?? null,
+            instagramId: $data['instagram_id'] ?? null,
+            twitterId: $data['twitter_id'] ?? null,
+        );
+    }
+}

--- a/src/Data/Movie.php
+++ b/src/Data/Movie.php
@@ -8,6 +8,8 @@ use Astrotomic\Tmdb\Collections\CompanyCollection;
 use Astrotomic\Tmdb\Collections\CountryCollection;
 use Astrotomic\Tmdb\Collections\GenreCollection;
 use Astrotomic\Tmdb\Collections\LanguageCollection;
+use Astrotomic\Tmdb\Collections\PersonCreditCollection;
+use Astrotomic\Tmdb\Collections\VideoCollection;
 use Astrotomic\Tmdb\Enums\MovieStatus;
 use Astrotomic\Tmdb\Images\Backdrop;
 use Astrotomic\Tmdb\Images\Poster;
@@ -34,18 +36,29 @@ readonly class Movie
         public CountryCollection $productionCountries,
         public ?CarbonImmutable $releaseDate,
         public ?int $revenue,
-        public ?CarbonInterval $runtime,
+        public ?CarbonInterval    $runtime,
         public LanguageCollection $spokenLanguages,
-        public ?MovieStatus $status,
-        public ?string $tagline,
-        public string $title,
-        public ?bool $video,
-        public ?float $voteAverage,
-        public ?int $voteCount,
+        public ?MovieStatus       $status,
+        public ?string            $tagline,
+        public string             $title,
+        public ?bool              $video,
+        public ?float             $voteAverage,
+        public ?int               $voteCount,
+        public ?VideoCollection   $videos,
+        public ?ExternalIds       $externalIds,
+        public ?AlternativeTitle  $alternativeTitles,
+        public ?array $credits,
     ) {}
 
     public static function fromArray(array $data): self
     {
+        $credits = [];
+
+        if(isset($data['credits'])){
+            $credits['cast'] = empty($data['credits']['cast']) ? null : PersonCreditCollection::fromArray($data['credits']['cast']);
+            $credits['crew'] = empty($data['credits']['crew']) ? null : PersonCreditCollection::fromArray($data['credits']['crew']);
+        }
+
         return new static(
             adult: $data['adult'],
             backdropPath: $data['backdrop_path'],
@@ -72,6 +85,10 @@ readonly class Movie
             video: $data['video'] ?? null,
             voteAverage: $data['vote_average'] ?? null,
             voteCount: $data['vote_count'] ?? null,
+            videos: VideoCollection::fromArray($data['videos']['results'] ?? null),
+            externalIds: empty($data['external_ids']) ? null : ExternalIds::fromArray($data['external_ids']),
+            alternativeTitles: empty($data['alternative_titles']) ? null : AlternativeTitle::fromArray($data['alternative_titles']),
+            credits: empty($credits) ? null : $credits,
         );
     }
 

--- a/src/Data/PersonCredit.php
+++ b/src/Data/PersonCredit.php
@@ -33,7 +33,6 @@ readonly class PersonCredit
         return new static(
             adult: $data['adult'] ?? null,
             id: $data['id'],
-            job: empty($data['job']) ? null : Job::from($data['job']),
             department: empty($data['department']) ? null : Department::from($data['department']),
             knownForDepartment: empty($data['known_for_department']) ? null : Department::from($data['known_for_department']),
             creditId: $data['credit_id'],
@@ -45,6 +44,7 @@ readonly class PersonCredit
             castId: $data['cast_id'] ?? null,
             character: $data['character'] ?? null,
             order: $data['order'] ?? null,
+            job: empty($data['job']) ? null : Job::from($data['job']),
         );
     }
 

--- a/src/Data/Title.php
+++ b/src/Data/Title.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Astrotomic\Tmdb\Data;
+
+readonly class Title
+{
+    final public function __construct(
+        public string $iso3166,
+        public string $title,
+        public ?string $type,
+    ){}
+
+    public static function fromArray(array $data): self
+    {
+        return new static(
+            iso3166: $data['iso_3166_1'],
+            title: $data['title'],
+            type: $data['type'] ?? null,
+        );
+    }
+}

--- a/src/Data/Video.php
+++ b/src/Data/Video.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Astrotomic\Tmdb\Data;
+
+readonly class Video
+{
+    final public function __construct(
+        public string $iso639,
+        public string $iso3166,
+        public string $name,
+        public string $key,
+        public string $site,
+        public int $size,
+        public string $type,
+        public bool $official,
+        public string $publishedAt,
+        public string $id,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new static(
+            iso639: $data['iso_639_1'],
+            iso3166: $data['iso_3166_1'],
+            name: $data['name'],
+            key: $data['key'],
+            site: $data['site'],
+            size: $data['size'],
+            type: $data['type'],
+            official: $data['official'],
+            publishedAt: $data['published_at'],
+            id: $data['id'],
+        );
+    }
+}

--- a/src/Requests/Movies/GetDetailsRequest.php
+++ b/src/Requests/Movies/GetDetailsRequest.php
@@ -19,11 +19,18 @@ class GetDetailsRequest extends Request
 
     protected Method $method = Method::GET;
 
-    public function __construct(public readonly int $id) {}
+    public function __construct(public readonly int $id, public readonly ?string $append_to_response = null) {}
 
     public function resolveEndpoint(): string
     {
         return "/movie/{$this->id}";
+    }
+
+    public function defaultQuery(): array
+    {
+        return array_filter([
+            'append_to_response' => $this->append_to_response,
+        ]);
     }
 
     public function createDtoFromResponse(Response $response): Movie

--- a/src/Resources/Movies.php
+++ b/src/Resources/Movies.php
@@ -22,10 +22,10 @@ use Saloon\Http\BaseResource;
 
 class Movies extends BaseResource
 {
-    public function getDetails(int $id): Movie
+    public function getDetails(int $id, ?string $append_to_response = null): Movie
     {
         return $this->connector->send(
-            new GetDetailsRequest($id)
+            new GetDetailsRequest($id, $append_to_response)
         )->dto();
     }
 


### PR DESCRIPTION
This PR includes support for the optional `appends_to_response ` as described [here](https://developer.themoviedb.org/docs/append-to-response). It includes few covered cases.

Ex:
```php
$tmdb = new TMDB($token);

$movies = $tmdb->movies()->getDetails(550, 'videos,credits,external_ids,alternative_titles');
```